### PR TITLE
Disable IZD

### DIFF
--- a/sound/pci/ca0106/ca0106.h
+++ b/sound/pci/ca0106/ca0106.h
@@ -582,7 +582,7 @@
 #define SPI_PL_BIT_R_R		(2<<7)	/* right channel = right */
 #define SPI_PL_BIT_R_C		(3<<7)	/* right channel = (L+R)/2 */
 #define SPI_IZD_REG		2
-#define SPI_IZD_BIT		(1<<4)	/* infinite zero detect */
+#define SPI_IZD_BIT		(0<<4)	/* infinite zero detect */
 
 #define SPI_FMT_REG		3
 #define SPI_FMT_BIT_RJ		(0<<0)	/* right justified mode */


### PR DESCRIPTION
On SB0570 automute functionality results in clicking sound before and after any sound output.
Infinite zero detect bit is cleared to deactivate functionality and supress the resulting noise.
The modification is tested on SB0570 with success. 
I think the zero crossing detection (DZCEN bit) might be inactive and this results in jumps at the output waveform. Altough the DZCEN bit is not defined in this header, its default value 0 enables zero crossing detection according to the WM8768 datasheet. Thus I assume that it is enabled so I had to disable automute.

some bug reports addressing this issue :
https://ubuntuforums.org/showthread.php?t=1697317
https://ubuntuforums.org/showthread.php?t=1660564
http://www.spinics.net/linux/fedora/alsa-user/msg09902.html
(for instance when you are time skipping a video or audio it clicks twice and is audible regardless of attenuation setting so it is quite annoying)
