### PR TITLE
ALSA: usb-audio: Add registration quirk for Kingston HyperX Cloud Flight S

### DIFF
--- a/sound/usb/quirks.c
+++ b/sound/usb/quirks.c
@@ -1857,6 +1857,7 @@ struct registration_quirk {
 static const struct registration_quirk registration_quirks[] = {
 	REG_QUIRK_ENTRY(0x0951, 0x16d8, 2),	/* Kingston HyperX AMP */
 	REG_QUIRK_ENTRY(0x0951, 0x16ed, 2),	/* Kingston HyperX Cloud Alpha S */
+	REG_QUIRK_ENTRY(0x0951, 0x16ea, 2),     /* Kingston HyperX Cloud Flight S */
 	{ 0 }					/* terminator */
 };
 


### PR DESCRIPTION
Similar to the Kingston HyperX AMP, the Kingston HyperX Cloud
Alpha S (0951:0x16ea) uses two interfaces, but only the second
interface contains the capture stream. This patch delays the
registration until the second interface appears.